### PR TITLE
Minor bugfixes (python environment, spaces in commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Find copy-n-pastable tests for a subsystem
 ./get_tests.py -s 'KUNIT TEST'
 ```
 ```
-./tools/testing/kunit/kunit.pyrun --kunitconfig lib/kunit
+./tools/testing/kunit/kunit.py run --kunitconfig lib/kunit
 ```
 

--- a/get_tests.py
+++ b/get_tests.py
@@ -48,8 +48,8 @@ class TestPlan:
         output = ""
         for test in self.tests.values():
             wd = f"cd {test['Working Directory']} && " if test['Working Directory'] else ""
-            env = f"{test['Env']}" if test['Env'] else ""
-            param = f"{test['Param']}" if test['Param'] else ""
+            env = f"{test['Env']} " if test['Env'] else ""
+            param = f" {test['Param']}" if test['Param'] else ""
 
             output += f"{wd}{env}{test['Cmd']}{param}"
 

--- a/get_tests.py
+++ b/get_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 # Copyright Don Zickus <dzickus@redhat.com>
 


### PR DESCRIPTION
This fixes a couple of small issues with get_tests.py:
- It doesn't work on (at least my) Debian-based system, as we need to explicitly ask for python3
- There are no spaces between the environment variables, command, and params. This causes them to run together, which makes them invalid.